### PR TITLE
Update master-job.yaml's nfd-worker flag -prune to --prune

### DIFF
--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -20,6 +20,6 @@ spec:
           command:
             - "nfd-master"
           args:
-            - "-prune"
+            - "--prune"
       restartPolicy: Never
 


### PR DESCRIPTION
This yaml file is used to delete the labels generated by NFD